### PR TITLE
Fix mobile knowledge card alignment

### DIFF
--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -373,8 +373,6 @@ ul.intro-social-buttons > li {
 .knowledge-cards > div {
     display: flex;
     margin-bottom: 24px;
-    flex: 0 0 100%;
-    max-width: 100%;
 }
 
 .knowledge-card {
@@ -487,20 +485,6 @@ ul.intro-social-buttons > li {
     }
 }
 
-@media (min-width: 992px) {
-    .knowledge-cards > div {
-        flex: 0 0 50%;
-        max-width: 50%;
-    }
-}
-
-@media (min-width: 1200px) {
-    .knowledge-cards > div {
-        flex: 0 0 33.3333%;
-        max-width: 33.3333%;
-    }
-}
-
 @media(max-width:767px) {
     .intro-header {
         min-height: auto;
@@ -560,6 +544,11 @@ ul.intro-social-buttons > li {
 
     .section-divider {
         height: 40px;
+    }
+
+    .knowledge-cards > div {
+        flex: 0 0 100%;
+        max-width: 100%;
     }
 }
 

--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -373,6 +373,8 @@ ul.intro-social-buttons > li {
 .knowledge-cards > div {
     display: flex;
     margin-bottom: 24px;
+    flex: 0 0 100%;
+    max-width: 100%;
 }
 
 .knowledge-card {
@@ -482,6 +484,20 @@ ul.intro-social-buttons > li {
     .intro-message,
     .knowledge-card {
         animation: none;
+    }
+}
+
+@media (min-width: 992px) {
+    .knowledge-cards > div {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+}
+
+@media (min-width: 1200px) {
+    .knowledge-cards > div {
+        flex: 0 0 33.3333%;
+        max-width: 33.3333%;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Mobile knowledge cards were sizing to their content and not lining up consistently across rows on small viewports. 
- The cards are rendered in a flex row (`.knowledge-cards`) with each item as a column, so an explicit flex-basis/max-width is required for predictable alignment. 
- Aligning the card column sizing with common Bootstrap breakpoints simplifies layout behavior across device widths. 
- Keep the existing card styling and entrance animations intact while fixing the alignment.

### Description
- Updated `css/landing-page.css` to set `.knowledge-cards > div` to `flex: 0 0 100%` and `max-width: 100%` so cards are full-width on small screens. 
- Added a `@media (min-width: 992px)` rule to make card columns `50%` width for medium/large devices. 
- Added a `@media (min-width: 1200px)` rule to make card columns `33.3333%` width for extra-large devices. 
- No changes were made to HTML templates; ` _includes/knowledge-map.html` remains the source of the card markup and continues to work with the updated CSS.

### Testing
- Attempted to run the site with `bundle exec jekyll serve --livereload --trace`, which failed in this environment due to a missing `Gemfile` (automated serve step failed). 
- There is no repository automated test suite to run for layout changes, so visual/manual validation is recommended on mobile viewports after building the site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959e7b74ae883238dc46b23f115982e)