### PR TITLE
Refine landing page styling fallbacks and focus states

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,4 @@
-<section id="home">
+<section id="home" class="home-section">
 	<div class="intro-header">
 
 		<div class="container">

--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -24,19 +24,19 @@ html {
 }
 
 body {
-    color: var(--ink);
-    font-family: var(--font-body);
+    color: var(--ink, #1f2422);
+    font-family: var(--font-body, "Work Sans", "Helvetica Neue", Helvetica, Arial, sans-serif);
     line-height: 1.6;
     background: linear-gradient(130deg, #fff7ec 0%, #f4f5ef 45%, #eaf4f1 100%);
 }
 
 a {
-    color: var(--accent);
+    color: var(--accent, #d85a3a);
 }
 
 a:hover,
 a:focus {
-    color: var(--accent-dark);
+    color: var(--accent-dark, #b8482f);
     text-decoration: none;
 }
 
@@ -46,7 +46,7 @@ h3,
 h4,
 h5,
 h6 {
-    font-family: var(--font-display);
+    font-family: var(--font-display, "Fraunces", "Times New Roman", serif);
     font-weight: 600;
     letter-spacing: -0.02em;
 }
@@ -69,6 +69,7 @@ h6 {
     overflow: hidden;
 }
 
+/* Decorative radial highlights for the hero background. */
 .intro-header::before {
     content: "";
     position: absolute;
@@ -100,7 +101,7 @@ h6 {
     text-transform: uppercase;
     letter-spacing: 0.3em;
     font-size: 0.8em;
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
     margin-bottom: 18px;
 }
 
@@ -110,9 +111,9 @@ h6 {
 }
 
 .intro-message > h3 {
-    font-family: var(--font-body);
+    font-family: var(--font-body, "Work Sans", "Helvetica Neue", Helvetica, Arial, sans-serif);
     font-weight: 500;
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
     margin: 0 0 18px;
 }
 
@@ -120,7 +121,7 @@ h6 {
     max-width: 720px;
     margin: 0 auto 22px;
     font-size: 1.1em;
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
 }
 
 .intro-divider {
@@ -139,8 +140,8 @@ h6 {
 }
 
 .btn-primary {
-    background-color: var(--accent);
-    border-color: var(--accent);
+    background-color: var(--accent, #d85a3a);
+    border-color: var(--accent, #d85a3a);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     font-size: 0.85em;
@@ -148,14 +149,14 @@ h6 {
 
 .btn-primary:hover,
 .btn-primary:focus {
-    background-color: var(--accent-dark);
-    border-color: var(--accent-dark);
+    background-color: var(--accent-dark, #b8482f);
+    border-color: var(--accent-dark, #b8482f);
 }
 
 .btn-ghost {
     background-color: transparent;
-    border: 1px solid var(--border);
-    color: var(--ink);
+    border: 1px solid var(--border, rgba(31, 36, 34, 0.12));
+    color: var(--ink, #1f2422);
     text-transform: uppercase;
     letter-spacing: 0.08em;
     font-size: 0.85em;
@@ -163,8 +164,13 @@ h6 {
 
 .btn-ghost:hover,
 .btn-ghost:focus {
-    border-color: var(--accent);
-    color: var(--accent);
+    border-color: var(--accent, #d85a3a);
+    color: var(--accent, #d85a3a);
+}
+
+.btn:focus-visible {
+    outline: 2px solid var(--accent, #d85a3a);
+    outline-offset: 2px;
 }
 
 ul.intro-social-buttons {
@@ -182,23 +188,23 @@ ul.intro-social-buttons > li {
 
 .intro-social-buttons .btn {
     background-color: rgba(255, 255, 255, 0.85);
-    border-color: var(--border);
-    color: var(--ink);
+    border-color: var(--border, rgba(31, 36, 34, 0.12));
+    color: var(--ink, #1f2422);
 }
 
 .intro-social-buttons .btn:hover,
 .intro-social-buttons .btn:focus {
-    border-color: var(--accent);
-    color: var(--accent);
+    border-color: var(--accent, #d85a3a);
+    color: var(--accent, #d85a3a);
 }
 
 .knowledge-section {
     position: relative;
     padding: 60px 0;
-    background-color: var(--surface);
+    background-color: var(--surface, #fff7ec);
 }
 
-#home + .knowledge-section {
+.home-section + .knowledge-section {
     padding-top: 40px;
 }
 
@@ -211,6 +217,7 @@ ul.intro-social-buttons > li {
 }
 
 .section-divider {
+    /* Maintain a consistent spacer between grouped sections. */
     height: 56px;
     background: linear-gradient(160deg, #fff4e6 0%, #f2f7f4 55%, #e9f4f1 100%);
 }
@@ -223,13 +230,13 @@ ul.intro-social-buttons > li {
     max-width: 560px;
     margin: 0 auto;
     border-radius: 999px;
-    border: 1px solid var(--border);
+    border: 1px solid var(--border, rgba(31, 36, 34, 0.12));
     padding: 12px 18px;
-    box-shadow: var(--shadow);
+    box-shadow: var(--shadow, 0 20px 45px rgba(31, 36, 34, 0.12));
 }
 
 .search-input:focus {
-    border-color: var(--accent);
+    border-color: var(--accent, #d85a3a);
     box-shadow: 0 0 0 2px rgba(216, 90, 58, 0.15);
 }
 
@@ -257,9 +264,9 @@ ul.intro-social-buttons > li {
     display: inline-block;
     padding: 6px 14px;
     border-radius: 999px;
-    border: 1px solid var(--border);
-    background-color: var(--panel);
-    color: var(--ink);
+    border: 1px solid var(--border, rgba(31, 36, 34, 0.12));
+    background-color: var(--panel, #fffdf8);
+    color: var(--ink, #1f2422);
     font-size: 0.85em;
     font-weight: 600;
     cursor: pointer;
@@ -267,14 +274,14 @@ ul.intro-social-buttons > li {
 }
 
 .search-filter input:checked + label {
-    background-color: var(--accent);
-    border-color: var(--accent);
+    background-color: var(--accent, #d85a3a);
+    border-color: var(--accent, #d85a3a);
     color: #fff;
 }
 
 .search-filter label:hover,
 .search-filter label:focus {
-    border-color: var(--accent);
+    border-color: var(--accent, #d85a3a);
 }
 
 .search-filter input:focus + label {
@@ -287,23 +294,23 @@ ul.intro-social-buttons > li {
     flex-wrap: wrap;
     justify-content: center;
     gap: 12px;
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
     font-size: 0.9em;
 }
 
 .search-count {
-    color: var(--ink);
+    color: var(--ink, #1f2422);
     font-weight: 600;
 }
 
 .search-empty,
 .search-error {
-    color: var(--accent-dark);
+    color: var(--accent-dark, #b8482f);
 }
 
 .search-hint {
     margin-top: 10px;
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
     font-size: 0.9em;
 }
 
@@ -311,9 +318,9 @@ ul.intro-social-buttons > li {
     margin-top: 12px;
     padding: 24px;
     border-radius: 18px;
-    border: 1px solid var(--border);
+    border: 1px solid var(--border, rgba(31, 36, 34, 0.12));
     background-color: rgba(255, 255, 255, 0.85);
-    box-shadow: var(--shadow);
+    box-shadow: var(--shadow, 0 20px 45px rgba(31, 36, 34, 0.12));
 }
 
 .search-results-list {
@@ -323,7 +330,7 @@ ul.intro-social-buttons > li {
 
 .search-result {
     padding: 16px 0;
-    border-bottom: 1px solid var(--border);
+    border-bottom: 1px solid var(--border, rgba(31, 36, 34, 0.12));
 }
 
 .search-result:last-child {
@@ -336,22 +343,22 @@ ul.intro-social-buttons > li {
 }
 
 .search-title a {
-    color: var(--ink);
+    color: var(--ink, #1f2422);
 }
 
 .search-title a:hover,
 .search-title a:focus {
-    color: var(--accent);
+    color: var(--accent, #d85a3a);
 }
 
 .search-snippet {
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
     margin-bottom: 6px;
 }
 
 .search-link {
     font-size: 0.85em;
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
 }
 
 .is-hidden {
@@ -359,7 +366,7 @@ ul.intro-social-buttons > li {
 }
 
 .section-lede {
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
     font-size: 1.05em;
     margin-bottom: 30px;
 }
@@ -380,9 +387,9 @@ ul.intro-social-buttons > li {
     width: 100%;
     padding: 24px;
     border-radius: 18px;
-    border: 1px solid var(--border);
-    background-color: var(--panel);
-    box-shadow: var(--shadow);
+    border: 1px solid var(--border, rgba(31, 36, 34, 0.12));
+    background-color: var(--panel, #fffdf8);
+    box-shadow: var(--shadow, 0 20px 45px rgba(31, 36, 34, 0.12));
     animation: rise-fade 0.9s ease-out both;
 }
 
@@ -416,30 +423,30 @@ ul.intro-social-buttons > li {
 }
 
 .knowledge-card h3 a {
-    color: var(--ink);
+    color: var(--ink, #1f2422);
 }
 
 .knowledge-card h3 a:hover,
 .knowledge-card h3 a:focus {
-    color: var(--accent);
+    color: var(--accent, #d85a3a);
 }
 
 .card-eyebrow {
     text-transform: uppercase;
     letter-spacing: 0.18em;
     font-size: 0.7em;
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
     margin-bottom: 12px;
 }
 
 .card-summary {
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
 }
 
 .card-list {
     padding-left: 18px;
     margin: 14px 0 0;
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
 }
 
 .card-list li {
@@ -460,7 +467,7 @@ ul.intro-social-buttons > li {
     text-transform: uppercase;
     letter-spacing: 0.12em;
     background-color: rgba(31, 36, 34, 0.08);
-    color: var(--muted);
+    color: var(--muted, #4b5a55);
     padding: 4px 8px;
     border-radius: 999px;
 }
@@ -534,7 +541,7 @@ ul.intro-social-buttons > li {
         padding: 50px 0;
     }
 
-    #home + .knowledge-section {
+    .home-section + .knowledge-section {
         padding-top: 36px;
     }
 


### PR DESCRIPTION
### Motivation
- Reduce selector specificity that relied on an ID-adjacent selector for spacing between the hero and the first knowledge section.  
- Improve robustness for browsers that don't support CSS custom properties by adding sensible fallbacks.  
- Improve keyboard accessibility by ensuring interactive elements have visible focus outlines.  
- Add small documentation comments for decorative/spacing intent to make future edits clearer.  

### Description
- Add a `home-section` class to the hero `section` in `_includes/header.html` and use `.home-section + .knowledge-section` in CSS to replace the `#home + .knowledge-section` selector.  
- Add fallback values for many CSS custom properties (colors, fonts, borders, shadows) across `css/landing-page.css`.  
- Add a visible keyboard focus style via `.btn:focus-visible` and update various hover/focus color fallbacks for buttons and interactive elements.  
- Add a couple of inline comments (hero decorative highlights and section divider intent) and tighten a few spacing/box-shadow defaults.  

### Testing
- Ran `bundle exec jekyll build` which failed with: "Could not locate Gemfile or .bundle/ directory".  
- The repository contains no automated test suite, so no other automated tests were executed.  
- Recommended validation: run `bundle exec jekyll serve --livereload --trace` and manually verify hero/knowledge spacing, button focus outlines, and search/filter controls.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ecd391e88323ab9d85ab02d36508)