### PR TITLE
fix search input dark mode

### DIFF
--- a/css/landing-page.css
+++ b/css/landing-page.css
@@ -247,8 +247,14 @@ ul.intro-social-buttons > li {
     margin: 0 auto;
     border-radius: var(--radius-pill, 999px);
     border: 1px solid var(--border, rgba(31, 36, 34, 0.12));
+    background-color: var(--panel, #fffdf8);
+    color: var(--ink, #1f2422);
     padding: 12px 18px;
     box-shadow: var(--shadow, 0 20px 45px rgba(31, 36, 34, 0.12));
+}
+
+.search-input::placeholder {
+    color: var(--muted, #4b5a55);
 }
 
 .search-input:focus {


### PR DESCRIPTION
### Motivation
- The archive search input used light defaults that produced poor contrast in dark mode and became hard to read.
- The site already exposes theme variables for dark and light modes, so aligning the input with those variables preserves consistent theming.

### Description
- Updated `css/landing-page.css` to set `.search-input` background to `var(--panel)` and text color to `var(--ink)` so it respects dark mode variables.
- Added a `.search-input::placeholder` rule to use `var(--muted)` for placeholder text so the hint color matches the theme.
- The change is limited to `css/landing-page.css` and was committed with the message `fix search input dark mode`.

### Testing
- Attempted to run the dev server with `bundle exec jekyll serve --livereload --trace`, but it failed due to a missing `Gemfile`/.bundle and could not be started locally.
- No automated visual or unit tests were available or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959f55053c48323a995a407d31007ae)